### PR TITLE
Fixed error check if no plugins exist

### DIFF
--- a/includes/widget.php
+++ b/includes/widget.php
@@ -64,8 +64,8 @@ class wptallyconnect_widget extends WP_Widget {
         if( $instance['username'] ) {
             $data = wptallyconnect_get_data( $instance['username'] );
 
-            if( array_key_exists( 'error', $data ) ) {
-                echo $data['error'];
+            if( array_key_exists( 'error', $data['plugins'] ) ) {
+                echo $data['plugins']['error'];
             } else {
                 // Do stuff
                 var_dump( $data );


### PR DESCRIPTION
The `array_key_exists` check wasn't working and still outputting the `else` statement. This PR fixes that.
